### PR TITLE
Fix creation of dangling drectory without nummeric suffix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ impl TempDir {
     /// New Temp dir.
     pub fn new<P: AsRef<Path>>(path: P, destroy: bool) -> Self {
         let mut path = PathBuf::from(path.as_ref());
-        Self::create_root(&path);
+        if let Some(parent) = path.parent() {
+            Self::create_root(&parent);
+        }
         while std::fs::create_dir(&path).is_err() {
             let val = {
                 path.extension().unwrap_or(OsStr::new(""))


### PR DESCRIPTION
`create_root` creates the leaf directory without a nummeric suffix. This
directory does not get cleaned up. This change calls `create_root` with
the parent directory of the temporary directories. If there is no parent
directory the call is skiped. This prevents a dangling directory from
being created.